### PR TITLE
Add a test case and fix for file { mode => undef }

### DIFF
--- a/lib/puppet-lint/plugins/world_writable_files.rb
+++ b/lib/puppet-lint/plugins/world_writable_files.rb
@@ -9,6 +9,8 @@ PuppetLint.new_check(:world_writable_files) do
           # get the file modes value
           value_token = param_token.next_code_token.next_code_token
 
+          # we only work with octal for now - also stops file { mode => undef }
+          break if value_token.value !~ /^\d+$/
           break if value_token.value =~ /\d+[^2367]$/
 
           notify :warning, {

--- a/spec/puppet-lint/plugins/puppet-lint-world_writable_files_spec.rb
+++ b/spec/puppet-lint/plugins/puppet-lint-world_writable_files_spec.rb
@@ -18,6 +18,23 @@ describe 'world_writable_files' do
     end
   end
 
+  context 'file with a mode of undef' do
+    let(:code) do
+      <<-EOS
+        class undef_file_mode {
+          file { '/tmp/undef_file_mode':
+            ensure => 'file',
+            mode   => undef,
+          }
+        }
+      EOS
+    end
+
+    it 'should not detect any problems' do
+      expect(problems).to have(0).problems
+    end
+  end
+
   context 'file with a world writable octal mode of 666' do
     let(:msg) { 'files should not be created with world writable permissions' }
     let(:code) do
@@ -39,4 +56,6 @@ describe 'world_writable_files' do
       expect(problems).to contain_warning(msg).on_line(4).in_column(23)
     end
   end
+
+
 end


### PR DESCRIPTION
Found this in the wild and it was causing a warning to be emitted
incorrectly.