### PR TITLE
Bump versions to get tests passing on modern rubies.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,9 @@
 language: ruby
 sudo: false
 rvm:
-  - 1.9.3
   - 2.0.0
-  - 2.1.0
+  - 2.2.0
+  - 2.3.0
 script: "bundle exec rake spec SPEC_OPTS='--format documentation'"
 notifications:
   email: dean.wilson@gmail.com

--- a/puppet-lint-world_writable_files-check.gemspec
+++ b/puppet-lint-world_writable_files-check.gemspec
@@ -19,9 +19,10 @@ Gem::Specification.new do |spec|
   EOF
 
   spec.add_dependency             'puppet-lint', '>= 1.1', '< 3.0'
-  spec.add_development_dependency 'rspec', '~> 3.0'
+  spec.add_development_dependency 'rspec', '~> 3.5.0'
   spec.add_development_dependency 'rspec-its', '~> 1.0'
   spec.add_development_dependency 'rspec-collection_matchers', '~> 1.0'
-  spec.add_development_dependency 'rubocop', '~> 0.36.0'
-  spec.add_development_dependency 'rake'
+  spec.add_development_dependency 'rubocop', '~> 0.47.1'
+  spec.add_development_dependency 'rake', '~> 11.2.0'
+  spec.add_development_dependency 'rspec-json_expectations', '~> 1.4'
 end


### PR DESCRIPTION
Also puppet-lint now seems to require `rspec-json_expectations`