### PR TITLE
Rename parameter

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -15,7 +15,7 @@ Layout/HashAlignment:
 
 Metrics/BlockLength:
   Max: 35
-  ExcludedMethods: [ 'describe' ]
+  IgnoredMethods: [ 'describe' ]
 
 Metrics/MethodLength:
   Max: 25


### PR DESCRIPTION
```
obsolete parameter `ExcludedMethods` (for `Metrics/BlockLength`) found in .rubocop.yml
`ExcludedMethods` has been renamed to `IgnoredMethods`
```